### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 ##########################################################
 
-TokenProcessor KEYWORD1
+TokenProcessor	KEYWORD1
 
 ##########################################################
 # Methods and Functions (KEYWORD2)
 ##########################################################
 
-nextToken KEYWORD2
-clearBuffer KEYWORD2
-getCommand KEYWORD2
-process KEYWORD2
-Channel KEYWORD2
-processCommand KEYWORD2
-getCommand KEYWORD2
+nextToken	KEYWORD2
+clearBuffer	KEYWORD2
+getCommand	KEYWORD2
+process	KEYWORD2
+Channel	KEYWORD2
+processCommand	KEYWORD2
+getCommand	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords